### PR TITLE
Round star coordinates before converting to array coords

### DIFF
--- a/regularizepsf/fitter.py
+++ b/regularizepsf/fitter.py
@@ -361,8 +361,8 @@ class CoordinatePatchCollection(PatchCollectionABC):
                                             err=background.globalrms)
 
             coordinates = [CoordinateIdentifier(i,
-                                                int(y - psf_size * interpolation_scale / 2),
-                                                int(x - psf_size * interpolation_scale / 2))
+                                                int(round(y - psf_size * interpolation_scale / 2)),
+                                                int(round(x - psf_size * interpolation_scale / 2)))
                            for x, y in zip(image_star_coords["x"], image_star_coords["y"])]
 
             # pad in case someone selects a region on the edge of the image


### PR DESCRIPTION
Here's the change I've mentioned elsewhere of rounding the identified stellar coordinates before `int`-ifying them. It doesn't seem to affect any of the existing tests.

Before the change, I get patches like this:
![image](https://user-images.githubusercontent.com/23462789/230161921-0236b290-4751-47b0-bfe0-62b2a08250d0.png)

And after:
![image](https://user-images.githubusercontent.com/23462789/230161954-b1c19a67-547e-4467-a180-e65b5703914a.png)

Note that the after image shows more symmetric PSFs, and that the patches tend to span the range [0, 1] much better.