### PR TITLE
Take stellar cutouts from the BG-subtracted image

### DIFF
--- a/regularizepsf/fitter.py
+++ b/regularizepsf/fitter.py
@@ -368,7 +368,7 @@ class CoordinatePatchCollection(PatchCollectionABC):
             # pad in case someone selects a region on the edge of the image
             padding_shape = ((psf_size * interpolation_scale, psf_size * interpolation_scale),
                              (psf_size * interpolation_scale, psf_size * interpolation_scale))
-            padded_image = np.pad(image, 
+            padded_image = np.pad(image_background_removed,
                                   padding_shape, 
                                   mode="constant", 
                                   constant_values=np.median(image))


### PR DESCRIPTION
What do you think about this change---using SEP's background-subtracted image as the source for the stellar cutouts? It improves the cleanliness of my WISPR patches.

Before:
![image](https://user-images.githubusercontent.com/23462789/230164262-940c7e53-2054-4e82-a842-b814547b37eb.png)

After:
![image](https://user-images.githubusercontent.com/23462789/230164289-7b3c67a9-78f7-43b3-9291-48daa3cc63b3.png)
