### PR TITLE
Avoid numpy dtype deprecation warnings

### DIFF
--- a/regularizepsf/helper.pyx
+++ b/regularizepsf/helper.pyx
@@ -20,16 +20,16 @@ cpdef _correct_image(np.ndarray[np.float_t, ndim=2] image,
     cdef int size = values_fft.shape[1]
     cdef int i = 0, j=0, xx = 0, yy = 0
     cdef int this_x, this_y, this_x_prime, this_y_prime
-    cdef np.ndarray[np.float_t, ndim=2] img_i = np.empty((size, size), dtype=np.float)
-    cdef np.ndarray[DTYPE_t, ndim=2] psf_i = np.empty((size, size), dtype=np.float)
-    cdef np.ndarray[DTYPE_t, ndim=2] corrected_i = np.empty((size, size), dtype=np.float)
+    cdef np.ndarray[np.float_t, ndim=2] img_i = np.empty((size, size), dtype=float)
+    cdef np.ndarray[DTYPE_t, ndim=2] psf_i = np.empty((size, size), dtype=float)
+    cdef np.ndarray[DTYPE_t, ndim=2] corrected_i = np.empty((size, size), dtype=float)
     cdef np.ndarray[DTYPE_t, ndim=2] padded_img = np.pad(image, ((2 * size, 2* size), (2*size, 2*size)),
                                                          mode="constant")
-    cdef np.ndarray[DTYPE_t, ndim=2] result_img = np.zeros_like(padded_img, dtype=np.float)
+    cdef np.ndarray[DTYPE_t, ndim=2] result_img = np.zeros_like(padded_img, dtype=float)
     cdef float psf_i_hat_abs
-    cdef np.ndarray[np.complex128_t, ndim=2] psf_i_hat_norm = np.empty((size, size), dtype=np.complex)
-    cdef np.ndarray[np.complex128_t, ndim=2] img_i_hat = np.empty((size, size), dtype=np.complex)
-    cdef np.ndarray[np.complex128_t, ndim=2] temp = np.empty((size, size), dtype=np.complex)
+    cdef np.ndarray[np.complex128_t, ndim=2] psf_i_hat_norm = np.empty((size, size), dtype=complex)
+    cdef np.ndarray[np.complex128_t, ndim=2] img_i_hat = np.empty((size, size), dtype=complex)
+    cdef np.ndarray[np.complex128_t, ndim=2] temp = np.empty((size, size), dtype=complex)
     cdef np.ndarray[np.float_t, ndim=2] apodization_window
 
 
@@ -71,8 +71,8 @@ cpdef _precalculate_ffts(np.ndarray[DTYPE_t, ndim=2] target_evaluation, np.ndarr
     cdef int size = values.shape[1]
     cdef int num_patches = values.shape[0]
     cdef np.ndarray[np.complex128_t, ndim=2] psf_target_hat = fft2(target_evaluation)
-    cdef np.ndarray[np.complex128_t, ndim=3] psf_i_hat = np.empty((num_patches, size, size), dtype=np.complex)
-    cdef np.ndarray[np.float_t, ndim=2] holder = np.empty((size, size), dtype=np.float)
+    cdef np.ndarray[np.complex128_t, ndim=3] psf_i_hat = np.empty((num_patches, size, size), dtype=complex)
+    cdef np.ndarray[np.float_t, ndim=2] holder = np.empty((size, size), dtype=float)
 
     for patch_i in range(num_patches):
         for xx in range(size):


### PR DESCRIPTION
Just want to clean up some warnings I'm seeing when running `pytest`. This eliminates the following from the warning log:

```
tests/test_corrector.py::test_create_array_corrector
tests/test_corrector.py::test_create_array_corrector
tests/test_corrector.py::test_evaluate_to_array_form_with_ones_and_no_target
tests/test_corrector.py::test_evaluate_to_array_form_with_ones_and_target
tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_array_corrector_correct_image_with_image_smaller_than_psf
tests/test_corrector.py::test_array_corrector_get_nonexistent_point
tests/test_corrector.py::test_array_corrector_simulate_observation_with_zero_stars
tests/test_corrector.py::test_functional_corrector_simulate_observation
  /home/svankooten/Documents/Research/Sun/WISPR/regularizepsf/regularizepsf/corrector.py:239: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    self.target_fft, self.psf_i_fft = _precalculate_ffts(self._target_evaluation,

tests/test_corrector.py::test_create_array_corrector
tests/test_corrector.py::test_create_array_corrector
tests/test_corrector.py::test_evaluate_to_array_form_with_ones_and_no_target
tests/test_corrector.py::test_evaluate_to_array_form_with_ones_and_target
tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_array_corrector_correct_image_with_image_smaller_than_psf
tests/test_corrector.py::test_array_corrector_get_nonexistent_point
tests/test_corrector.py::test_array_corrector_simulate_observation_with_zero_stars
tests/test_corrector.py::test_functional_corrector_simulate_observation
  /home/svankooten/Documents/Research/Sun/WISPR/regularizepsf/regularizepsf/corrector.py:239: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    self.target_fft, self.psf_i_fft = _precalculate_ffts(self._target_evaluation,


...


tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_functional_corrector_correct_image
  /home/svankooten/Documents/Research/Sun/WISPR/regularizepsf/regularizepsf/corrector.py:253: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return _correct_image(image,

tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_functional_corrector_correct_image
tests/test_corrector.py::test_functional_corrector_correct_image
  /home/svankooten/Documents/Research/Sun/WISPR/regularizepsf/regularizepsf/corrector.py:253: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return _correct_image(image,
```


`To silence this warning, ... Doing this will not modify any behavior and is safe.`
:relaxed:



