### PR TITLE
Align interpolation points to data points

### DIFF
--- a/regularizepsf/fitter.py
+++ b/regularizepsf/fitter.py
@@ -346,12 +346,12 @@ class CoordinatePatchCollection(PatchCollectionABC):
                 interpolator = RectBivariateSpline(np.arange(image.shape[0]), 
                                                    np.arange(image.shape[1]), 
                                                    image)
-                image = interpolator(np.linspace(0, 
-                                                 image.shape[0], 
-                                                 image.shape[0] * interpolation_scale),
-                                     np.linspace(0, 
-                                                 image.shape[1], 
-                                                 image.shape[1] * interpolation_scale))
+                image = interpolator(np.linspace(0,
+                                                 image.shape[0] - 1,
+                                                 1 + (image.shape[0] - 1) * interpolation_scale),
+                                     np.linspace(0,
+                                                 image.shape[1] - 1,
+                                                 1 + (image.shape[1] - 1) * interpolation_scale))
 
             # find stars using SEP
             background = sep.Background(image)


### PR DESCRIPTION
When the input images are interpolated in `find_stars_and_average`, the grid of interpolated points drifts slightly from the actual data points, and it also extends beyond the image by one pixel. [As-is](https://github.com/punch-mission/regularizepsf/blob/941fc85c8c80e4fd5bacf1b49720411f32f62953/regularizepsf/fitter.py#L349), it interpolates the image to these points:
```
image = np.empty((5,5))
interpolation_scale = 4
np.linspace(0, image.shape[0], image.shape[0] * interpolation_scale)

array([0.        , 0.26315789, 0.52631579, 0.78947368, 1.05263158,
       1.31578947, 1.57894737, 1.84210526, 2.10526316, 2.36842105,
       2.63157895, 2.89473684, 3.15789474, 3.42105263, 3.68421053,
       3.94736842, 4.21052632, 4.47368421, 4.73684211, 5.        ])
```

If this is adjusted, the interpolated points will include exactly the data points, as well as exactly the half-way etc. spot between data points:
```
np.linspace(0, image.shape[0] - 1, 1 + (image.shape[0] - 1) * interpolation_scale)
# Note, np.arange(0, image.shape[0] - 0.99999, 1 / interpolation_scale) is equivalent---not sure which is cleaner

array([0.  , 0.25, 0.5 , 0.75, 1.  , 1.25, 1.5 , 1.75, 2.  , 2.25, 2.5 ,
       2.75, 3.  , 3.25, 3.5 , 3.75, 4.  ])
```

I'm assuming the latter is desirable, but I'm not sure if there's some subtle reason it should be the former.

(This doesn't seem to be having any significant impact on what I'm getting with WISPR images when I use the interpolation mode.)