### PR TITLE
Use tmp_path for temp file in test

### DIFF
--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -106,17 +106,17 @@ def example_psf(x, y):
     return 0
 
 
-def test_create_functional_corrector():
+def test_create_functional_corrector(tmp_path):
     example = FunctionalCorrector(example_psf, example_psf)
     assert example._psf == example_psf
     assert example.is_variable is False
     assert example._target_model == example_psf
 
-    example.save("test.psf")
-    assert os.path.isfile("test.psf")
-    loaded = example.load("test.psf")
+    fname = tmp_path / "test.psf"
+    example.save(fname)
+    assert os.path.isfile(fname)
+    loaded = example.load(fname)
     assert isinstance(loaded, FunctionalCorrector)
-    os.remove("test.psf")
 
 
 def test_evaluate_to_array_form_with_invalid_size_errors():
@@ -199,17 +199,17 @@ def test_array_corrector_get_nonexistent_point():
         patch = corr[(1, 1)]
 
 
-def test_create_array_corrector():
+def test_save_load_array_corrector(tmp_path):
     evaluations = {(0, 0): np.ones((100, 100))}
     target = np.ones((100, 100))
     example = ArrayCorrector(evaluations, target)
     assert len(example._evaluations) == 1
 
-    example.save("test.psf")
-    assert os.path.isfile("test.psf")
-    loaded = example.load("test.psf")
+    fname = tmp_path / "test.psf"
+    example.save(fname)
+    assert os.path.isfile(fname)
+    loaded = example.load(fname)
     assert isinstance(loaded, ArrayCorrector)
-    os.remove("test.psf")
 
 
 def test_array_corrector_simulate_observation_with_zero_stars():


### PR DESCRIPTION
A small tweak for the tests---using a tmp dir for the tests that save and load files. Without this change, one of these tests would sometimes fail when I used `pytest-xdist` to run tests across multiple cores, I assume because they were trampling each other's output files.

I also noticed that `test_create_array_corrector`, which I've re-named `test_save_load_array_corrector`, was overwriting another test in that file also called `test_create_array_corrector`.