### PR TITLE
Normalize patches by the star-center value rather than the patch maximum

### DIFF
--- a/regularizepsf/fitter.py
+++ b/regularizepsf/fitter.py
@@ -476,7 +476,7 @@ class CoordinatePatchCollection(PatchCollectionABC):
 
         for identifier, patch in self.patches.items():
             # Normalize the patch
-            patch = patch / np.max(patch)
+            patch = patch / patch[psf_size//2, psf_size//2]
 
             # Determine which average region it belongs to
             center_x = identifier.x + self.size // 2

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -81,7 +81,7 @@ def test_coordinate_patch_average():
              })
     for patch in collection.values():
         # Make the normalization of each patch a no-op
-        patch[-1, -1] = 1
+        patch[5, 5] = 1
 
     averaged_collection = collection.average(
             np.array([[0, 0]]), 10, 10, mode='median')


### PR DESCRIPTION
Btw if you're gearing up for another release, there was one last local change I never pushed. When the cutouts of each star are being collected, each one gets normalized. The was done by dividing each patch by its maximum value. In cases where there's some contaminant in the patch that's brighter than the star, the normalized star is in the range [0, small] instead of [0, 1] and so doesn't contribute well to the final PSF model. I changed it to use the patch-center value (i.e. the star's center and presumably peak value) rather than the patch's maximum value, to help ensure that the stars are all normalized the same. Any bright contaminants will be normalized to values > 1, but since they're hopefully rare, that shouldn't really affect the median/percentile/whatever.

If the patch sizes are small, hopefully these contaminants are pretty rare and this is a low-impact change.

What do you think?