### PR TITLE
revert-python-bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "regularizepsf"
 copyright = "2023, J. Marcus Hughes and the PUNCH Science Operations Center"
 author = "J. Marcus Hughes and the PUNCH Science Operations Center"
-release = "0.3.1"
+release = "0.3.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ ext_modules = [Extension("regularizepsf.helper",
 
 setup(
     name="regularizepsf",
-    python_requires=">=3.10",
+    python_requires=">=3.9",
     version="0.3.1",
     description="Point spread function modeling and regularization",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ ext_modules = [Extension("regularizepsf.helper",
 setup(
     name="regularizepsf",
     python_requires=">=3.9",
-    version="0.3.1",
+    version="0.3.2",
     description="Point spread function modeling and regularization",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## PR summary

Reverts the bump to require Python 3.10

## Todos

- [x] make sure it doesn't break anything

## Test plan

- Let CI run

## Breaking changes

No

## Related Issues

No