### PR TITLE
fix python 3.12 CI failure, enable numpy 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install .
-        python setup.py pytest --addopts "--cov ."
+        coverage run -m pytest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         ruff check .
     - name: Test with pytest
       run: |
-        pip install .
         coverage run -m pytest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[test]"
+        pip install -e ".[test]"
     - name: Lint with ruff
       run: |
         ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.26.4", "Cython>=0.29.21"]
+requires = ["setuptools", "wheel", "numpy", "Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -11,11 +11,11 @@ version = "0.3.4"
 requires-python = ">3.10"
 description = "Point spread function modeling and regularization"
 dependencies = [
-      "numpy==1.26.4",
+      "numpy",
       "dill",
       "h5py",
       "lmfit",
-      "sep",
+      "sep-pjw",
       "cython",
       "astropy",
       "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,52 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.19.0, <2.0.0", "Cython>=0.29.21"]
+requires = ["setuptools", "wheel", "numpy", "Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["regularizepsf"]
+
+[project]
+name = "regularizepsf"
+version = "0.3.4"
+requires-python = ">3.10"
+description = "Point spread function modeling and regularization"
+dependencies = [
+      "numpy==1.26.4",
+      "dill",
+      "h5py",
+      "lmfit",
+      "sep",
+      "cython",
+      "astropy",
+      "scipy",
+      "scikit-image",
+      "matplotlib",
+      "setuptools"
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+
+[project.optional-dependencies]
+test = [
+     "pytest",
+     "pytest-cov",
+     "hypothesis",
+     "coverage",
+     "ruff",
+     "pytest-mpl",
+]
+docs = [
+    "sphinx",
+    "pydata-sphinx-theme",
+    "sphinx-autoapi"
+]
+
+dev = ["regularizepsf[test, docs]", "pre-commit"]
+
 
 [tool.ruff]
 exclude = ['tests/*']
-line-length=120
+line-length = 120
 
 #[tool.ruff.lint]
 #select = ["NPY201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = ["regularizepsf"]
 
 [project]
 name = "regularizepsf"
-version = "0.3.4"
+version = "0.3.5"
 requires-python = ">3.10"
 description = "Point spread function modeling and regularization"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython>=0.29.21"]
+requires = ["setuptools", "wheel", "numpy==1.26.4", "Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -11,7 +11,7 @@ version = "0.3.4"
 requires-python = ">3.10"
 description = "Point spread function modeling and regularization"
 dependencies = [
-      "numpy",
+      "numpy==1.26.4",
       "dill",
       "h5py",
       "lmfit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.3.4"
 requires-python = ">3.10"
 description = "Point spread function modeling and regularization"
 dependencies = [
-      "numpy==1.26.4",
+      "numpy",
       "dill",
       "h5py",
       "lmfit",

--- a/regularizepsf/fitter.py
+++ b/regularizepsf/fitter.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 import h5py
 import numpy as np
-import sep
+import sep_pjw as sep
 from astropy.io import fits
 from lmfit import Parameters, minimize
 from lmfit.minimizer import MinimizerResult

--- a/regularizepsf/helper.pyx
+++ b/regularizepsf/helper.pyx
@@ -8,11 +8,11 @@ ctypedef np.float_t DTYPE_t
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef _correct_image(np.ndarray[np.float, ndim=2] image,
-                     np.ndarray[np.complex, ndim=2] target_fft,
-                     np.ndarray[np.int, ndim=1] x,
-                     np.ndarray[np.int, ndim=1] y,
-                     np.ndarray[np.complex, ndim=3] values_fft,
+cpdef _correct_image(np.ndarray[double, ndim=2] image,
+                     np.ndarray[complex, ndim=2] target_fft,
+                     np.ndarray[long, ndim=1] x,
+                     np.ndarray[long, ndim=1] y,
+                     np.ndarray[complex, ndim=3] values_fft,
                      float alpha,
                      float epsilon):
     """Core Cython code to actually correct an image"""

--- a/regularizepsf/helper.pyx
+++ b/regularizepsf/helper.pyx
@@ -8,11 +8,11 @@ ctypedef np.float_t DTYPE_t
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef _correct_image(np.ndarray[np.float_t, ndim=2] image,
-                     np.ndarray[np.complex128_t, ndim=2] target_fft,
-                     np.ndarray[np.int_t, ndim=1] x,
-                     np.ndarray[np.int_t, ndim=1] y,
-                     np.ndarray[np.complex128_t, ndim=3] values_fft,
+cpdef _correct_image(np.ndarray[np.float, ndim=2] image,
+                     np.ndarray[np.complex, ndim=2] target_fft,
+                     np.ndarray[np.int, ndim=1] x,
+                     np.ndarray[np.int, ndim=1] y,
+                     np.ndarray[np.complex, ndim=3] values_fft,
                      float alpha,
                      float epsilon):
     """Core Cython code to actually correct an image"""

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 import numpy as np
 from Cython.Build import cythonize
-from setuptools import Extension, setup
+from setuptools import setup
 
 # with open("README.md", "r", encoding="utf-8") as fh:
 #     long_description = fh.read()
 
-ext_modules = [Extension("regularizepsf.helper",
-                         sources=["regularizepsf/helper.pyx"],
-                         include_dirs=[np.get_include()])]
+# ext_modules = [Extension("regularizepsf.helper",
+#                          sources=["regularizepsf/helper.pyx"],
+#                          include_dirs=[np.get_include()])]
 
 setup(
     # name="regularizepsf",
@@ -21,7 +21,10 @@ setup(
     # license="MIT",
     # author="J. Marcus Hughes",
     # author_email="hughes.jmb@gmail.com",
-    ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={"language_level": 3}),
+    # ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={"language_level": 3}),
+    ext_modules=cythonize("regularizepsf/helper.pyx"),
+    include_dirs=[np.get_include()]
+
     # install_requires=["numpy==1.26.4",
     #                   "dill",
     #                   "h5py",

--- a/setup.py
+++ b/setup.py
@@ -2,47 +2,7 @@ import numpy as np
 from Cython.Build import cythonize
 from setuptools import setup
 
-# with open("README.md", "r", encoding="utf-8") as fh:
-#     long_description = fh.read()
-
-# ext_modules = [Extension("regularizepsf.helper",
-#                          sources=["regularizepsf/helper.pyx"],
-#                          include_dirs=[np.get_include()])]
-
 setup(
-    # name="regularizepsf",
-    # python_requires=">=3.10",
-    # version="0.3.4",
-    # description="Point spread function modeling and regularization",
-    # long_description=long_description,
-    # long_description_content_type="text/markdown",
-    # packages=["regularizepsf"],
-    # url="https://github.com/punch-mission/regularizepsf",
-    # license="MIT",
-    # author="J. Marcus Hughes",
-    # author_email="hughes.jmb@gmail.com",
-    # ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={"language_level": 3}),
     ext_modules=cythonize("regularizepsf/helper.pyx"),
     include_dirs=[np.get_include()]
-
-    # install_requires=["numpy==1.26.4",
-    #                   "dill",
-    #                   "h5py",
-    #                   "lmfit",
-    #                   "sep",
-    #                   "cython",
-    #                   "astropy",
-    #                   "scipy",
-    #                   "scikit-image",
-    #                   "matplotlib",
-    #                   "setuptools"],
-    # package_data={"regularizepsf": ["helper.pyx"]},
-    # setup_requires=["cython"],
-    # extras_require={"test": ["pytest",
-    #                          "pytest-cov",
-    #                          "hypothesis",
-    #                          "coverage",
-    #                          "ruff",
-    #                          "pytest-mpl",
-    #                          "pre-commit"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     setup_requires=["cython"],
     extras_require={"test": ["pytest",
                              "pytest-cov",
-                             "pytest-runner",
                              "hypothesis",
                              "ruff",
                              "pytest-mpl",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     extras_require={"test": ["pytest",
                              "pytest-cov",
                              "hypothesis",
+                             "coverage",
                              "ruff",
                              "pytest-mpl",
                              "pre-commit"]}

--- a/setup.py
+++ b/setup.py
@@ -2,44 +2,44 @@ import numpy as np
 from Cython.Build import cythonize
 from setuptools import Extension, setup
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
+# with open("README.md", "r", encoding="utf-8") as fh:
+#     long_description = fh.read()
 
 ext_modules = [Extension("regularizepsf.helper",
                          sources=["regularizepsf/helper.pyx"],
                          include_dirs=[np.get_include()])]
 
 setup(
-    name="regularizepsf",
-    python_requires=">=3.10",
-    version="0.3.4",
-    description="Point spread function modeling and regularization",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    packages=["regularizepsf"],
-    url="https://github.com/punch-mission/regularizepsf",
-    license="MIT",
-    author="J. Marcus Hughes",
-    author_email="hughes.jmb@gmail.com",
+    # name="regularizepsf",
+    # python_requires=">=3.10",
+    # version="0.3.4",
+    # description="Point spread function modeling and regularization",
+    # long_description=long_description,
+    # long_description_content_type="text/markdown",
+    # packages=["regularizepsf"],
+    # url="https://github.com/punch-mission/regularizepsf",
+    # license="MIT",
+    # author="J. Marcus Hughes",
+    # author_email="hughes.jmb@gmail.com",
     ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={"language_level": 3}),
-    install_requires=["numpy==1.26.4",
-                      "dill",
-                      "h5py",
-                      "lmfit",
-                      "sep",
-                      "cython",
-                      "astropy",
-                      "scipy",
-                      "scikit-image",
-                      "matplotlib",
-                      "setuptools"],
-    package_data={"regularizepsf": ["helper.pyx"]},
-    setup_requires=["cython"],
-    extras_require={"test": ["pytest",
-                             "pytest-cov",
-                             "hypothesis",
-                             "coverage",
-                             "ruff",
-                             "pytest-mpl",
-                             "pre-commit"]}
+    # install_requires=["numpy==1.26.4",
+    #                   "dill",
+    #                   "h5py",
+    #                   "lmfit",
+    #                   "sep",
+    #                   "cython",
+    #                   "astropy",
+    #                   "scipy",
+    #                   "scikit-image",
+    #                   "matplotlib",
+    #                   "setuptools"],
+    # package_data={"regularizepsf": ["helper.pyx"]},
+    # setup_requires=["cython"],
+    # extras_require={"test": ["pytest",
+    #                          "pytest-cov",
+    #                          "hypothesis",
+    #                          "coverage",
+    #                          "ruff",
+    #                          "pytest-mpl",
+    #                          "pre-commit"]}
 )


### PR DESCRIPTION
## PR summary

- removes requirement on pytest-runner since it's deprecated and archived

## Todos

None

## Test plan

Make the CI pass!

## Breaking changes

None

## Related Issues

resolves #183 