### PR TITLE
Allow a single star mask to be provided

### DIFF
--- a/regularizepsf/builder.py
+++ b/regularizepsf/builder.py
@@ -23,6 +23,11 @@ def _convert_to_generator(images:  list[pathlib.Path] | np.ndarray | Generator,
             def generator() -> np.ndarray:
                 yield from images
             data_iterator = generator()
+        elif len(images.shape) == 2:
+            def generator() -> np.ndarray:
+                while True:
+                    yield images
+            data_iterator = generator()
         else:
             msg = "Image data array must be 3D"
             raise IncorrectShapeError(msg)


### PR DESCRIPTION
## PR summary

Tell me what you think about this. I think it's a reasonable use case that you have a stack of images, and a single star mask that applies to all images. Currently, that has to be passed in as
```python
    def masks():
        while True:
            yield mask
ArrayPSFBuilder(psf_size).build(input_filepaths, hdu_choice=1, star_masks=masks())
```

I think it would be nice to just pass in the array.


## Todos

This maybe opens other questions like "How about passing a single file path instead of a list of paths?" If you're OK going this way, this PR can be a bookmark for doing that sometime.

## Test plan

I ran it and it ran.

## Breaking changes

None