### PR TITLE
Add plot options to support large grids of PSFs

### DIFF
--- a/changelog/252.feature.rst
+++ b/changelog/252.feature.rst
@@ -1,0 +1,1 @@
+Expanded plot options for grid-type plots

--- a/regularizepsf/psf.py
+++ b/regularizepsf/psf.py
@@ -335,7 +335,25 @@ class ArrayPSF:
                   edge_trim: int = 1,
                   patch_stride: int = 1,
                   imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
-        """Visualize the PSF model."""
+        """Visualize the PSFs.
+
+        Parameters
+        ----------
+        fig : mp.figure.Figure
+            the figure to plot in
+        fig_scale : int
+            increasing this will make the figure higher resolution
+        edge_trim : int
+            how many pixels to drop on each side of the PSF for plotting
+        patch_stride : int
+            multiple of how many patches to skip when plotting, 1 means no skipping, 2 plots every other, 3 every third
+        imshow_args : dict
+            additional arguments for imshow
+
+        Returns
+        -------
+        None
+        """
         imshow_args = PSF_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
         visualize_grid(self._values_cube, fig=fig, fig_scale=fig_scale, patch_stride=patch_stride,
                        edge_trim=edge_trim, colorbar_label="Normalized brightness",
@@ -347,7 +365,25 @@ class ArrayPSF:
                   edge_trim: int = 1,
                   patch_stride: int = 1,
                   imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
-        """Visualize the fft of the PSF."""
+        """Visualize the FFT kernels.
+
+        Parameters
+        ----------
+        fig : mp.figure.Figure
+            the figure to plot in
+        fig_scale : int
+            increasing this will make the figure higher resolution
+        edge_trim : int
+            how many pixels to drop on each side of the PSF for plotting
+        patch_stride : int
+            multiple of how many patches to skip when plotting, 1 means no skipping, 2 plots every other, 3 every third
+        imshow_args : dict
+            additional arguments for imshow
+
+        Returns
+        -------
+        None
+        """
         imshow_args = KERNEL_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
 
         arr = np.abs(np.fft.fftshift(np.fft.ifft2(self._fft_cube.values)))

--- a/regularizepsf/psf.py
+++ b/regularizepsf/psf.py
@@ -332,17 +332,21 @@ class ArrayPSF:
     def visualize_psfs(self,
                   fig: mpl.figure.Figure | None = None,
                   fig_scale: int = 1,
-                  all_patches: bool = False, imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
+                  edge_trim: int = 1,
+                  patch_stride: int = 1,
+                  imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
         """Visualize the PSF model."""
         imshow_args = PSF_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
-        visualize_grid(self._values_cube, fig=fig, fig_scale=fig_scale, all_patches=all_patches,
-                       colorbar_label="Normalized brightness",
+        visualize_grid(self._values_cube, fig=fig, fig_scale=fig_scale, patch_stride=patch_stride,
+                       edge_trim=edge_trim, colorbar_label="Normalized brightness",
                        imshow_args=imshow_args)
 
     def visualize_ffts(self,
                   fig: mpl.figure.Figure | None = None,
                   fig_scale: int = 1,
-                  all_patches: bool = False, imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
+                  edge_trim: int = 1,
+                  patch_stride: int = 1,
+                  imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
         """Visualize the fft of the PSF."""
         imshow_args = KERNEL_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
 
@@ -355,7 +359,7 @@ class ArrayPSF:
 
         return visualize_grid(
             IndexedCube(self._fft_cube.coordinates, arr),
-            all_patches=all_patches, fig=fig,
+            patch_stride=patch_stride, edge_trim=edge_trim, fig=fig,
             fig_scale=fig_scale, colorbar_label="Transfer kernel amplitude",
             imshow_args=imshow_args)
 

--- a/regularizepsf/transform.py
+++ b/regularizepsf/transform.py
@@ -182,7 +182,25 @@ class ArrayPSFTransform:
                   patch_stride: int = 1,
                   edge_trim: int = 1,
                   imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
-        """Visualize the transfer kernels."""
+        """Visualize the transform kernels.
+
+        Parameters
+        ----------
+        fig : mp.figure.Figure
+            the figure to plot in
+        fig_scale : int
+            increasing this will make the figure higher resolution
+        edge_trim : int
+            how many pixels to drop on each side of the PSF for plotting
+        patch_stride : int
+            multiple of how many patches to skip when plotting, 1 means no skipping, 2 plots every other, 3 every third
+        imshow_args : dict
+            additional arguments for imshow
+
+        Returns
+        -------
+        None
+        """
         imshow_args = KERNEL_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
 
         arr = np.abs(np.fft.fftshift(np.fft.ifft2(self._transfer_kernel.values)))

--- a/regularizepsf/transform.py
+++ b/regularizepsf/transform.py
@@ -177,9 +177,11 @@ class ArrayPSFTransform:
         ]
 
     def visualize(self,
-                          fig: mpl.figure.Figure | None = None,
-                          fig_scale: int = 1,
-                          all_patches: bool = False, imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
+                  fig: mpl.figure.Figure | None = None,
+                  fig_scale: int = 1,
+                  patch_stride: int = 1,
+                  edge_trim: int = 1,
+                  imshow_args: dict | None = None) -> None:  # noqa: ANN002, ANN003
         """Visualize the transfer kernels."""
         imshow_args = KERNEL_IMSHOW_ARGS_DEFAULT if imshow_args is None else imshow_args
 
@@ -192,8 +194,9 @@ class ArrayPSFTransform:
 
         return visualize_grid(
             IndexedCube(self._transfer_kernel.coordinates, arr),
-            all_patches=all_patches, fig=fig,
-            fig_scale=fig_scale, colorbar_label="Transfer kernel amplitude",
+            patch_stride=patch_stride,
+            edge_trim=edge_trim,
+            fig=fig, fig_scale=fig_scale, colorbar_label="Transfer kernel amplitude",
             imshow_args=imshow_args)
 
     def save(self, path: pathlib.Path, overwrite: bool = False) -> None:

--- a/regularizepsf/visualize.py
+++ b/regularizepsf/visualize.py
@@ -98,7 +98,32 @@ def visualize_grid(data: IndexedCube,
                    edge_trim: int = 0,
                    imshow_args: dict | None = None,
                    colorbar_label: str  = "") -> None:  # noqa: ANN002, ANN003
-    """Visualize the PSF model."""
+    """Visualize various indexed cubes.
+
+    Parameters
+    ----------
+    data : IndexedCube
+        primary data set to visualize
+    second_data : IndexedCube
+        second set of data visualize
+    title : str
+        plot title
+    fig : mp.figure.Figure
+        the figure to plot in
+    fig_scale : int
+        increasing this will make the figure higher resolution
+    edge_trim : int
+        how many pixels to drop on each side of the PSF for plotting
+    patch_stride : int
+        multiple of how many patches to skip when plotting, 1 means no skipping, 2 plots every other, 3 every third
+    imshow_args : dict
+        additional arguments for imshow
+    colorbar_label : str
+        label for the colorbar
+    Returns
+    -------
+    None
+    """
     # Identify which patches we'll be plotting
     rows = np.unique(sorted(r for r, c in data.coordinates))
     columns = np.unique(sorted(c for r, c in data.coordinates))

--- a/regularizepsf/visualize.py
+++ b/regularizepsf/visualize.py
@@ -94,16 +94,16 @@ def visualize_grid(data: IndexedCube,
                    title: str | tuple[str, str] = "",
                    fig: mpl.figure.Figure | None = None,
                    fig_scale: int = 1,
-                   all_patches: bool = False,
+                   patch_stride: int = 1,
+                   edge_trim: int = 0,
                    imshow_args: dict | None = None,
                    colorbar_label: str  = "") -> None:  # noqa: ANN002, ANN003
     """Visualize the PSF model."""
     # Identify which patches we'll be plotting
     rows = np.unique(sorted(r for r, c in data.coordinates))
     columns = np.unique(sorted(c for r, c in data.coordinates))
-    if not all_patches:
-        rows = rows[1::2]
-        columns = columns[1::2]
+    rows = rows[::patch_stride]
+    columns = columns[::patch_stride]
 
     # Work out the size of the image
     # Each grid of patches will be 6 inches wide
@@ -136,7 +136,10 @@ def visualize_grid(data: IndexedCube,
 
     for i, j in itertools.product(range(len(rows)), range(len(columns))):
         ax = fig.add_subplot(gs[len(rows) - 1 - i, j])
-        im = ax.imshow(data[rows[i], columns[j]], **imshow_args)
+        image = data[rows[i], columns[j]]
+        if edge_trim:
+            image = image[edge_trim:-edge_trim, edge_trim:-edge_trim]
+        im = ax.imshow(image, **imshow_args)
         # Ensure there's a thin line between subplots
         ax.spines[:].set_color("white")
         ax.set_xticks([])
@@ -149,6 +152,8 @@ def visualize_grid(data: IndexedCube,
         for i, j in itertools.product(range(len(rows)), range(len(columns))):
             ax = fig.add_subplot(gs[len(rows) - 1 - i, j + len(columns) + 1])
             image = second_data[(rows[i], columns[j])]
+            if edge_trim:
+                image = image[edge_trim:-edge_trim, edge_trim:-edge_trim]
             im = ax.imshow(image, **imshow_args)
             ax.spines[:].set_color("white")
             ax.set_xticks([])


### PR DESCRIPTION
We fit *lots* of PSFs for PUNCH, which makes some of the visualization functions unwieldy. For `ArrayPSFTransform.visualize`, instead of this:
<img width="1547" height="1405" alt="image" src="https://github.com/user-attachments/assets/26b451e5-7368-445a-857e-27daf8d0afb6" />

this PR lets you make this:
`psf.visualize(fig_scale=3, edge_trim=15, patch_stride=5)`
<img width="1547" height="1406" alt="image" src="https://github.com/user-attachments/assets/892ba7bf-fa4c-4384-8cdb-46d996fa62c4" />
